### PR TITLE
added chalk to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "agentkeepalive": "^2.0.3",
     "http-proxy": "^1.12.0",
     "istextorbinary": "^1.0.2",
-    "websocket": "^1.0.22"
+    "websocket": "^1.0.22",
+    "chalk": "^1.1.1"
   },
   "devDependencies": {
     "electron-prebuilt": "^0.34.0",


### PR DESCRIPTION
Application would fail to load with 

```
npm ERR! Darwin 15.0.0
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "start"
npm ERR! node v5.1.0
npm ERR! npm  v3.3.12
npm ERR! code ELIFECYCLE
npm ERR! betwixt@0.0.0 start: `electron main.js`
npm ERR! Exit status 7
npm ERR!
npm ERR! Failed at the betwixt@0.0.0 start script 'electron main.js'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the betwixt package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     electron main.js
npm ERR! You can get their info via:
npm ERR!     npm owner ls betwixt
npm ERR! There is likely additional logging output above.
```

Due to missing the `chalk` dependency.
