### PR TITLE
Use electron-packager to create an os x bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .idea
+bin/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .idea
 bin/
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -6,11 +6,20 @@ This tool will help you analyze web traffic outside the browser using familiar C
 
 **This project is in an early stage of development, things may break, values may not be accurate. All contributors are very welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) fore more details.**
 
-## How To Use
+
+## How To Install
+
+On the releases tab, you will find several packages. Choose the correct one to your operating system.
+
+## How to Build
 
 To clone and run this repository you'll need [Git](https://git-scm.com) and [Node.js 5.x](https://nodejs.org/en/download/) (which comes with [npm](http://npmjs.com)) installed on your computer. From your command line:
 
-### How To Install
+There are a few build scripts included in the `package.json` that allows you to create some binaries/bundles to your operating system.
+
+The files created by the following scripts are placed in a folder inside the `bin` folder.
+
+So from your command line:
 
 ```bash
 # Clone this repository
@@ -19,19 +28,7 @@ $ git clone https://github.com/kdzwinel/betwixt.git
 $ cd betwixt
 # Install nodeJS dependencies
 $ npm install
-# Build your the package application
 ```
-
-### Build application to your system
-
-There are a few build scripts included in the `package.json` that allows you to create some binaries/bundles to your operating system.
-
-The files created by the following scripts are placed in a folder inside the `bin` folder.
-
-So in your command line:
-
-* change to the directory where you clone this repository
-* run one (or more) of the options below
 
 #### Linux
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,65 @@ This tool will help you analyze web traffic outside the browser using familiar C
 
 To clone and run this repository you'll need [Git](https://git-scm.com) and [Node.js 5.x](https://nodejs.org/en/download/) (which comes with [npm](http://npmjs.com)) installed on your computer. From your command line:
 
+### How To Install
+
 ```bash
 # Clone this repository
 $ git clone https://github.com/kdzwinel/betwixt.git
 # Go into the repository
 $ cd betwixt
-# Install dependencies and run the app
-$ npm install && npm start
+# Install nodeJS dependencies
+$ npm install
+# Build your the package application
 ```
+
+### Build application to your system
+
+There are a few build scripts included in the `package.json` that allows you to create some binaries/bundles to your operating system.
+
+The files created by the following scripts are placed in a folder inside the `bin` folder.
+
+So in your command line:
+
+* change to the directory where you clone this repository
+* run one (or more) of the options below
+
+#### Linux
+
+```bash
+npm run build:linux
+```
+
+The output directory is `bin/Betwixt-linux-x64`
+
+#### Mac OS X
+
+```bash
+npm run build:osx
+```
+
+The output directory is `bin/Betwixt-darwin-x64`
+
+#### Windows
+
+```bash
+npm run build:win
+```
+
+It generates two directories, for 32 and 64 bits architectures. The folders are `bin/Betwixt-win32-ia32` or `bin/Betwixt-win32-x64`
+
+#### Custom build
+
+```bash
+npm run build:custom -- --platform=<all, linux, darwin, win32> --arch=<all, x86, x64>
+```
+
+If none of this builds mets your requirements, you can use the custom build script.
+You can send the `platform` and `arch` that you want to build. 
+
+So for example, if you want to build a binary for windows 32 bits only, you can run `npm run build:custom -- --platform=win32 --arch=x86`
+
+## Setting up
 
 In order to capture traffic, you'll have to direct it to the proxy created by Betwixt in the background (`http://localhost:8008`).
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "description": "Web Debugging Proxy based on Chrome DevTools Network panel",
   "main": "main.js",
   "scripts": {
-    "build": "electron-packager ./ Betwixt --platform=darwin --arch=x64 --version=0.35.0 --overwrite --out ./bin/",
+    "build": "npm run build:custom -- --platform=all --arch=all",
+    "build:custom": "electron-packager ./ Betwixt --overwrite --out ./bin/ --version=0.35.0",
+    "build:linux": "npm run build:custom -- --platform=linux --arch=all",
+    "build:osx": "npm run build:custom -- --platform=darwin --arch=x64",
+    "build:win": "npm run build:custom -- --platform=win32 --arch=all",
     "start": "electron main.js",
     "test": "jshint main.js lib/ && jscs main.js lib/"
   },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Web Debugging Proxy based on Chrome DevTools Network panel",
   "main": "main.js",
   "scripts": {
+    "build": "electron-packager ./ Betwixt --platform=darwin --arch=x64 --version=0.35.0 --overwrite --out ./bin/",
     "start": "electron main.js",
     "test": "jshint main.js lib/ && jscs main.js lib/"
   },
@@ -29,6 +30,7 @@
     "chalk": "^1.1.1"
   },
   "devDependencies": {
+    "electron-packager": "^5.1.1",
     "electron-prebuilt": "^0.34.0",
     "jscs": "^2.6.0",
     "jshint": "^2.8.0"


### PR DESCRIPTION
Hi, so first of all, congratulations for the work, it's really great app.

So, i usually like to have the applications as a bundle or brew formula (cask included), so this is just a pull request to allow the creation of os x bundle using electron packager.

This changes the `.gitignore` to include the `bin` folder and the `package.json` with the `electron-packager` dependency and an extra script.
