### PR TITLE
Remove unused UI elements 

### DIFF
--- a/dt/network/NetworkPanel.js
+++ b/dt/network/NetworkPanel.js
@@ -123,8 +123,6 @@ WebInspector.NetworkPanel.prototype = {
         this._clearButton.addEventListener("click", this._onClearButtonClicked, this);
         this._panelToolbar.appendToolbarItem(this._clearButton);
         this._panelToolbar.appendSeparator();
-        var recordFilmStripButton = new WebInspector.ToolbarSettingToggle(this._networkRecordFilmStripSetting, "camera-toolbar-item", WebInspector.UIString("Capture screenshots"));
-        this._panelToolbar.appendToolbarItem(recordFilmStripButton);
 
         this._panelToolbar.appendToolbarItem(this._filterBar.filterButton());
         this._panelToolbar.appendSeparator();
@@ -138,13 +136,6 @@ WebInspector.NetworkPanel.prototype = {
         var showOverviewButton = new WebInspector.ToolbarSettingToggle(this._networkLogShowOverviewSetting, "waterfall-toolbar-item", WebInspector.UIString("Show overview"), WebInspector.UIString("Hide overview"));
         this._panelToolbar.appendToolbarItem(showOverviewButton);
         this._panelToolbar.appendSeparator();
-
-        this._preserveLogCheckbox = new WebInspector.ToolbarCheckbox(WebInspector.UIString("Preserve log"), WebInspector.UIString("Do not clear log on page reload / navigation"));
-        this._preserveLogCheckbox.inputElement.addEventListener("change", this._onPreserveLogCheckboxChanged.bind(this), false);
-        this._panelToolbar.appendToolbarItem(this._preserveLogCheckbox);
-
-        this._disableCacheCheckbox = new WebInspector.ToolbarCheckbox(WebInspector.UIString("Disable cache"), WebInspector.UIString("Disable cache (while DevTools is open)"), WebInspector.moduleSetting("cacheDisabled"));
-        this._panelToolbar.appendToolbarItem(this._disableCacheCheckbox);
 
         this._panelToolbar.appendSeparator();
         this._panelToolbar.appendToolbarItem(this._createBlockedURLsButton());
@@ -183,7 +174,7 @@ WebInspector.NetworkPanel.prototype = {
 
     _toggleRecording: function()
     {
-        if (!this._preserveLogCheckbox.checked() && !this._recordButton.toggled())
+        if (!this._recordButton.toggled())
             this._reset();
         this._toggleRecordButton(!this._recordButton.toggled());
     },
@@ -225,14 +216,6 @@ WebInspector.NetworkPanel.prototype = {
     },
 
     /**
-     * @param {!Event} event
-     */
-    _onPreserveLogCheckboxChanged: function(event)
-    {
-        this._networkLogView.setPreserveLog(this._preserveLogCheckbox.checked());
-    },
-
-    /**
      * @param {!WebInspector.Event} event
      */
     _onClearButtonClicked: function(event)
@@ -255,8 +238,7 @@ WebInspector.NetworkPanel.prototype = {
      */
     _willReloadPage: function(event)
     {
-        if (!this._preserveLogCheckbox.checked())
-            this._reset();
+        this._reset();
         this._toggleRecordButton(true);
         if (this._pendingStopTimer) {
             clearTimeout(this._pendingStopTimer);

--- a/dt/network/NetworkPanel.js
+++ b/dt/network/NetworkPanel.js
@@ -139,7 +139,6 @@ WebInspector.NetworkPanel.prototype = {
 
         this._panelToolbar.appendSeparator();
         this._panelToolbar.appendToolbarItem(this._createBlockedURLsButton());
-        this._panelToolbar.appendToolbarItem(this._createNetworkConditionsSelect());
         this._panelToolbar.appendToolbarItem(new WebInspector.ToolbarItem(this._progressBarContainer));
     },
 


### PR DESCRIPTION
(preserve log, clear cache, screencapture, clear cookies, hide data URLs).

Sadly, there was no config to disable these elements. I'm still not sure if removing them from the DT code is the best way to hide them. Updating DT code in the future will get complicated. On the other hand, hiding them via `display:none` seems like a hack + it'd be hard to target all these elements via CSS (e.g. context menu).

Preview:
![betwixt-ui](https://cloud.githubusercontent.com/assets/985504/11412145/23e67680-93d9-11e5-8a7d-c2df277141b4.png)

Fixes #5 
