### PR TITLE
Add OS generated files into gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,16 @@ node_modules
 .idea
 bin/
 npm-debug.log
+
+# OS generated files #
+######################
+*/.DS_Store
+**/.DS_Store
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Icon?
+ehthumbs.db
+Thumbs.db


### PR DESCRIPTION
I think it will be better to include these file to gitignore, just in case other contributors accidentally add and commit these files. 
