### PR TITLE
Host/port binding and reverse proxy

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -13,9 +13,13 @@ $ cd betwixt
 $ npm install
 ```
 
-### Running
+### Running (regular proxy mode)
 
 You can run Betwixt right away using `npm start`.
+
+### Running with binding options and reverse proxy mode
+
+`npm start -- --proxy-port=8010 --proxy-host=0.0.0.0 --reverse-proxy=http://127.0.0.1:8081`
 
 ### Creating a bundle
 

--- a/lib/traffic-interceptor.js
+++ b/lib/traffic-interceptor.js
@@ -12,7 +12,7 @@ const getTime = require('./init-time');
  * Responsible for creating and maintaining proxy server and exposing information about passing traffic.
  */
 class TrafficInterceptor extends EventEmitter {
-    constructor(port) {
+    constructor(opts) {
         super();
 
         //TODO we never remove requests from here - see #8
@@ -31,7 +31,12 @@ class TrafficInterceptor extends EventEmitter {
             .on('error', (error) => {
                 this.emit('error', error);
             })
-            .listen(port);
+            .listen(opts.proxyPort, opts.proxyHost);
+
+        if (opts.reverseProxy) {
+            this._reverseProxy = opts.reverseProxy;
+            this._reverseProxyUrl = url.parse(opts.reverseProxy);
+        }
     }
 
     getConnection(id) {
@@ -45,11 +50,15 @@ function handleHTTPRequest(req, res) {
     let target = url.parse(req.url);
 
     this._proxy.web(req, res, {
-        target: target.protocol + '//' + target.host
+        target: this._reverseProxy || target.protocol + '//' + target.host
     });
 }
 
 function handleIncomingRequest(proxyReq, req, res, options) {
+    if (this._reverseProxy) {
+        proxyReq.setHeader('host', this._reverseProxyUrl.hostname + ':' + this._reverseProxyUrl.port);
+    }
+
     let connection = new CapturedConnection();
     connection.setRequest(proxyReq, req);
 

--- a/main.js
+++ b/main.js
@@ -6,9 +6,10 @@ const chalk = require('chalk');
 const FrontEndConnection = require('./lib/front-end-connection');
 const TrafficInterceptor = require('./lib/traffic-interceptor');
 const RDPMessageFormatter = require('./lib/rdp-message-formatter');
+const argv = require('minimist')(process.argv.slice(2));
 
-function init(webContents, proxyPort) {
-    let trafficInterceptor = new TrafficInterceptor(proxyPort);
+function init(webContents, opts) {
+    let trafficInterceptor = new TrafficInterceptor(opts);
     let frontEndConnection = new FrontEndConnection(webContents);
 
     // this part is responsible for answering devtools requests
@@ -60,6 +61,12 @@ function init(webContents, proxyPort) {
 // Report crashes to our server.
 require('crash-reporter').start();
 
+const opts = {
+    proxyPort: argv['proxy-port'] || 8008,
+    proxyHost: argv['proxy-host'],
+    reverseProxy: argv['reverse-proxy']
+};
+
 app.on('ready', () => {
 
     let mainWindow = new BrowserWindow({
@@ -68,7 +75,7 @@ app.on('ready', () => {
         height: 600
     });
 
-    init(mainWindow.webContents, 8008);
+    init(mainWindow.webContents, opts);
 
     mainWindow.loadUrl('file://' + __dirname + '/dt/inspector.html?electron=true');
 

--- a/package.json
+++ b/package.json
@@ -28,9 +28,10 @@
   "homepage": "https://github.com/kdzwinel/betwixt",
   "dependencies": {
     "agentkeepalive": "^2.0.3",
+    "chalk": "^1.1.1",
     "http-proxy": "^1.12.0",
     "istextorbinary": "^1.0.2",
-    "chalk": "^1.1.1"
+    "minimist": "^1.2.0"
   },
   "devDependencies": {
     "electron-packager": "^5.1.1",


### PR DESCRIPTION
- Adds command line configuration options to allow specifying the IP/port to bind to (`--proxy-host` and `--proxy-port`);
- Adds a command line options for activating a reverse proxy mode (i.e. forwards the requests to the same server, `--reverse-proxy`).
