### PR TITLE
Capture and show request body. Fixes #28

### DIFF
--- a/lib/captured-connection.js
+++ b/lib/captured-connection.js
@@ -27,11 +27,12 @@ class CapturedConnection {
         this._responseBody = null;
     }
 
-    setRequest(proxyReq, req) {
+    setRequest(proxyReq, req, body) {
         this._request = {
             url: req.url,
-            method: proxyReq.method,
-            headers: req.headers
+            method: req.method,
+            headers: req.headers,
+            postData: body
         };
     }
 

--- a/lib/rdp-message-formatter.js
+++ b/lib/rdp-message-formatter.js
@@ -18,7 +18,8 @@ function requestWillBeSent(connection) {
             method: request.method,
             headers: request.headers,
             initialPriority: 'High',
-            mixedContentType: 'none'
+            mixedContentType: 'none',
+            postData: request.postData
         },
         timestamp: connection.getTiming().start,
         wallTime: connection.getTiming().wallTime,

--- a/lib/traffic-interceptor.js
+++ b/lib/traffic-interceptor.js
@@ -51,14 +51,22 @@ function handleHTTPRequest(req, res) {
 
 function handleIncomingRequest(proxyReq, req, res, options) {
     let connection = new CapturedConnection();
-    connection.setRequest(proxyReq, req);
+    let body;
 
     this._connections.set(connection.getId(), connection);
+
     req.log = {
         id: connection.getId()
     };
 
-    this.emit('request', connection);
+    req.on('data', chunk => {
+        body = body || '';
+        body += chunk;
+    });
+    req.on('end', () => {
+        connection.setRequest(proxyReq, req, body);
+        this.emit('request', connection);
+    });
 }
 
 function handleIncomingResponse(proxyRes, req, res) {


### PR DESCRIPTION
TIL that all HTTP methods can have a body (not only POST).
This solution does work with file uploads but displays them in undesirable way. This will have to be fixed later.
