### PR TITLE
replacing http-proxy with http-mitm-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ If you wish to analyze traffic system wide:
 
 ![Setting up proxy on OS X](http://i.imgur.com/QL3cE6L.png)
 
-If you want to capture traffic coming from a single terminal (e.g. wget, npm) use `export http_proxy=http://localhost:8008`.
+If you want to capture traffic coming from a single terminal use `export http_proxy=http://localhost:8008`.
+
+For HTTPS instructions, see [this doc](docs/https.md).
 
 #### License [MIT](LICENSE.md)

--- a/docs/https.md
+++ b/docs/https.md
@@ -1,0 +1,29 @@
+## HTTPS
+
+### Root Certificate
+
+In order to capture encrypted traffic, you'll have to install root certificate provided by Betwixt.
+The certificate is generated for you when you first launch Betwixt. You will find it in the application data directory:
+
+- OS X - `~/Library/Application Support/betwixt/ssl/certs/`
+- Windows - `%APPDATA%\betwixt\ssl\certs\`
+- Linux - `$XDG_CONFIG_HOME/betwxit/ssl/certs/` or `~/.config/betwxit/ssl/certs/`
+
+When you find the right folder, import `ca.pem` and mark it as trusted.
+
+On OS X this is done via Keychain app as shown below.
+
+![Installing certificate on OS X](http://i.imgur.com/lm2TIw4.png)
+
+### Proxy
+
+Direct the traffic to the proxy created by Betwixt in the background (`http://localhost:8008`).
+
+If you wish to analyze traffic system wide:
+- on OS X - `System Preferences → Network → Advanced → Proxies → Secure Web Proxy (HTTPS)`
+- on Ubuntu - `All Settings → Network → Network Proxy`
+- on Windows - `PC Settings → Network → Proxy`
+
+![Setting up proxy on OS X](http://i.imgur.com/JslKSz8.png)
+
+If you want to capture traffic coming from a single terminal use `export https_proxy=http://localhost:8008`.

--- a/lib/captured-connection.js
+++ b/lib/captured-connection.js
@@ -1,8 +1,10 @@
 'use strict';
 
+const url = require('url');
 const zlib = require('zlib');
 const isTextOrBinary = require('istextorbinary');
 const getTime = require('./init-time');
+
 const generateConnectionId = (() => {
     let id = 1;
     return () => id++;
@@ -27,26 +29,28 @@ class CapturedConnection {
         this._responseBody = null;
     }
 
-    setRequest(proxyReq, req, body) {
+    setRequest(req, isSSL, body) {
         this._request = {
-            url: req.url,
+            url: fullUrl(req, isSSL),
             method: req.method,
             headers: req.headers,
             postData: body
         };
     }
 
-    setResponse(proxyRes, res) {
+    setResponse(res) {
         this._response = {
             url: res.url,
-            statusCode: proxyRes.statusCode,
-            statusMessage: proxyRes.statusMessage,
-            headers: flattenHeaders(proxyRes.headers),
-            rawHeaders: recreateRawResponseHeaders(proxyRes),
-            connectionId: res.connection.remotePort
+            statusCode: res.statusCode,
+            statusMessage: res.statusMessage,
+            headers: flattenHeaders(res.headers),
+            rawHeaders: recreateRawResponseHeaders(res),
+            connectionId: res.connection.localPort,
+            remoteAddress: res.connection.remoteAddress,
+            remotePort: res.connection.remotePort
         };
 
-        this._resourceType = getResourceType(proxyRes.headers['content-type']);
+        this._resourceType = getResourceType(res.headers['content-type']);
     }
 
     getId() {
@@ -130,6 +134,14 @@ class CapturedConnection {
     }
 }
 
+function fullUrl(req, isSSL) {
+    let parsedUrl = url.parse(req.url);
+    parsedUrl.protocol = isSSL ? 'https' : 'http';
+    parsedUrl.host = req.headers.host;
+
+    return url.format(parsedUrl);
+}
+
 //TODO should be async
 function unpackBody(buffer, encoding) {
     if (encoding === 'gzip') {
@@ -195,14 +207,14 @@ function getResourceType(contentType) {
 }
 
 //TODO try getting real raw response headers instead of this thing
-function recreateRawResponseHeaders(proxyRes) {
+function recreateRawResponseHeaders(res) {
     let headerString = '';
 
-    for (let i = 0, l = proxyRes.rawHeaders.length; i < l; i += 2) {
-        headerString += proxyRes.rawHeaders[i] + ': ' + proxyRes.rawHeaders[i + 1] + '\n';
+    for (let i = 0, l = res.rawHeaders.length; i < l; i += 2) {
+        headerString += res.rawHeaders[i] + ': ' + res.rawHeaders[i + 1] + '\n';
     }
 
-    return `HTTP/${proxyRes.httpVersion} ${proxyRes.statusCode} ${proxyRes.statusMessage}
+    return `HTTP/${res.httpVersion} ${res.statusCode} ${res.statusMessage}
 ${headerString}`;
 }
 

--- a/lib/rdp-message-formatter.js
+++ b/lib/rdp-message-formatter.js
@@ -68,8 +68,8 @@ function responseReceived(connection) {
                 receiveHeadersEnd: (connection.getTiming().responseReceived - connection.getTiming().start) * 1000
             },
             requestHeaders: connection.getRequest().headers,
-            remoteIPAddress: '127.0.0.1',
-            remotePort: 80
+            remoteIPAddress: response.remoteAddress,
+            remotePort: response.remotePort
         }
     };
 }

--- a/lib/traffic-interceptor.js
+++ b/lib/traffic-interceptor.js
@@ -9,7 +9,7 @@ const getTime = require('./init-time');
  * Responsible for creating and maintaining proxy server and exposing information about passing traffic.
  */
 class TrafficInterceptor extends EventEmitter {
-    constructor(port) {
+    constructor(options) {
         super();
 
         //TODO we never remove requests from here - see #8
@@ -21,7 +21,10 @@ class TrafficInterceptor extends EventEmitter {
         proxy.onResponse(handleIncomingResponse.bind(this));
         proxy.onError(handleProxyError.bind(this));
 
-        proxy.listen({port: port});
+        proxy.listen({
+            port: options.port,
+            sslCaDir: options.sslCaDir
+        });
     }
 
     getConnection(id) {

--- a/lib/traffic-interceptor.js
+++ b/lib/traffic-interceptor.js
@@ -109,7 +109,7 @@ function handleIncomingResponse(ctx, callback) {
 }
 
 function handleProxyError(ctx, error) {
-    this.emit('error', 'Proxy error:', error);
+    this.emit('error', 'Proxy error: ' + error);
 }
 
 module.exports = TrafficInterceptor;

--- a/lib/traffic-interceptor.js
+++ b/lib/traffic-interceptor.js
@@ -43,10 +43,14 @@ function handleIncomingRequest(ctx, callback) {
     ctx.onRequestData(function(ctx, chunk, callback) {
         chunks.push(chunk);
 
+        return callback(null, chunk);
+    });
+
+    ctx.onRequestEnd(function(ctx, callback) {
         connection.setRequest(ctx.clientToProxyRequest, ctx.isSSL, (Buffer.concat(chunks)).toString());
         trafficInterceptor.emit('request', connection);
 
-        return callback(null, chunk);
+        return callback();
     });
 
     return callback();

--- a/lib/traffic-interceptor.js
+++ b/lib/traffic-interceptor.js
@@ -1,10 +1,7 @@
 'use strict';
 
-const http = require('http');
-const httpProxy = require('http-proxy');
-const url = require('url');
+const MITMProxy = require('http-mitm-proxy');
 const EventEmitter = require('events');
-const Agent = require('agentkeepalive');
 const CapturedConnection = require('./captured-connection');
 const getTime = require('./init-time');
 
@@ -18,20 +15,13 @@ class TrafficInterceptor extends EventEmitter {
         //TODO we never remove requests from here - see #8
         this._connections = new Map();
 
-        let agent = new Agent({
-            keepAlive: true
-        });
+        let proxy = new MITMProxy();
 
-        this._proxy = httpProxy.createProxyServer({agent})
-            .on('proxyReq', handleIncomingRequest.bind(this))
-            .on('proxyRes', handleIncomingResponse.bind(this))
-            .on('error', handleProxyError.bind(this));
+        proxy.onRequest(handleIncomingRequest.bind(this));
+        proxy.onResponse(handleIncomingResponse.bind(this));
+        proxy.onError(handleProxyError.bind(this));
 
-        this._server = http.createServer(handleHTTPRequest.bind(this))
-            .on('error', (error) => {
-                this.emit('error', error);
-            })
-            .listen(port);
+        proxy.listen({port: port});
     }
 
     getConnection(id) {
@@ -39,40 +29,36 @@ class TrafficInterceptor extends EventEmitter {
     }
 }
 
-function handleHTTPRequest(req, res) {
-    this.emit('log', 'Request recorded: ' + req.method + ' ' + req.url);
-
-    let target = url.parse(req.url);
-
-    this._proxy.web(req, res, {
-        target: target.protocol + '//' + target.host
-    });
-}
-
-function handleIncomingRequest(proxyReq, req, res, options) {
+function handleIncomingRequest(ctx, callback) {
     let connection = new CapturedConnection();
-    let body;
 
     this._connections.set(connection.getId(), connection);
-
-    req.log = {
+    ctx.log = {
         id: connection.getId()
     };
 
-    req.on('data', chunk => {
-        body = body || '';
-        body += chunk;
+    let trafficInterceptor = this;
+    let chunks = [];
+
+    ctx.onRequestData(function(ctx, chunk, callback) {
+        chunks.push(chunk);
+
+        connection.setRequest(ctx.clientToProxyRequest, ctx.isSSL, (Buffer.concat(chunks)).toString());
+        trafficInterceptor.emit('request', connection);
+
+        return callback(null, chunk);
     });
-    req.on('end', () => {
-        connection.setRequest(proxyReq, req, body);
-        this.emit('request', connection);
-    });
+
+    return callback();
 }
 
-function handleIncomingResponse(proxyRes, req, res) {
-    this.emit('log', 'Response arrived: ' + req.method + ' ' + req.url + ' ' + res.statusCode);
+function handleIncomingResponse(ctx, callback) {
+    let request = ctx.clientToProxyRequest;
+    let response = ctx.serverToProxyResponse;
 
-    let connectionId = req.log && req.log.id;
+    this.emit('log', 'Response arrived: ' + request.method + ' ' + request.url + ' ' + response.statusCode);
+
+    let connectionId = ctx.log && ctx.log.id;
     let connection = null;
 
     if (connectionId) {
@@ -84,27 +70,23 @@ function handleIncomingResponse(proxyRes, req, res) {
         return;
     }
 
-    connection.setResponse(proxyRes, res);
+    connection.setResponse(response);
     connection.registerResponseReceived();
     this.emit('response-received', connection);
 
-    let _end = res.end;
-    let _write = res.write;
     let trafficInterceptor = this;
 
-    res.write = function(chunk) {
-        _write.apply(res, arguments);
+    ctx.onResponseData(function(ctx, chunk, callback) {
         connection.registerDataReceived(chunk);
 
         trafficInterceptor.emit('response-data', connection, {
-            time: getTime,
+            time: getTime(),
             encodedLength: chunk.length
         });
-    };
 
-    res.end = function() {
-        _end.apply(res, arguments);
-
+        return callback(null, chunk);
+    });
+    ctx.onResponseEnd(function(ctx, callback) {
         connection.registerResponseFinished();
 
         //after whole body was received and unpacked we can push its size to the front-end
@@ -115,10 +97,14 @@ function handleIncomingResponse(proxyRes, req, res) {
         });
 
         trafficInterceptor.emit('response-finished', connection);
-    };
+
+        return callback();
+    });
+
+    return callback();
 }
 
-function handleProxyError(error) {
+function handleProxyError(ctx, error) {
     this.emit('error', 'Proxy error:', error);
 }
 

--- a/main.js
+++ b/main.js
@@ -3,12 +3,16 @@
 const app = require('app');
 const BrowserWindow = require('browser-window');
 const chalk = require('chalk');
+const path = require('path');
 const FrontEndConnection = require('./lib/front-end-connection');
 const TrafficInterceptor = require('./lib/traffic-interceptor');
 const RDPMessageFormatter = require('./lib/rdp-message-formatter');
 
 function init(webContents, proxyPort) {
-    let trafficInterceptor = new TrafficInterceptor(proxyPort);
+    let trafficInterceptor = new TrafficInterceptor({
+        port: proxyPort,
+        sslCaDir: path.resolve(app.getPath('userData'), 'ssl')
+    });
     let frontEndConnection = new FrontEndConnection(webContents);
 
     // this part is responsible for answering devtools requests

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/kdzwinel/betwixt",
   "dependencies": {
     "chalk": "^1.1.1",
-    "http-mitm-proxy": "^0.2.0",
+    "http-mitm-proxy": "git://github.com/kdzwinel/node-http-mitm-proxy.git#onRequestEnd",
     "istextorbinary": "^1.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,9 +28,10 @@
   "homepage": "https://github.com/kdzwinel/betwixt",
   "dependencies": {
     "agentkeepalive": "^2.0.3",
+    "chalk": "^1.1.1",
+    "http-mitm-proxy": "^0.2.0",
     "http-proxy": "^1.12.0",
-    "istextorbinary": "^1.0.2",
-    "chalk": "^1.1.1"
+    "istextorbinary": "^1.0.2"
   },
   "devDependencies": {
     "electron-packager": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -27,10 +27,8 @@
   },
   "homepage": "https://github.com/kdzwinel/betwixt",
   "dependencies": {
-    "agentkeepalive": "^2.0.3",
     "chalk": "^1.1.1",
     "http-mitm-proxy": "^0.2.0",
-    "http-proxy": "^1.12.0",
     "istextorbinary": "^1.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/kdzwinel/betwixt",
   "dependencies": {
     "chalk": "^1.1.1",
-    "http-mitm-proxy": "git://github.com/kdzwinel/node-http-mitm-proxy.git#onRequestEnd",
+    "http-mitm-proxy": "^0.4.0",
     "istextorbinary": "^1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
I've replaced http-proxy with [http-mitm-proxy](https://github.com/joeferner/node-http-mitm-proxy) which is much better fit for this project. The biggest win? HTTPS support!

Things I've fixed BTW:
- remote port and remote address are now reported correctly to the front-end
- timestamp is now correctly passed to the front-end with each "dataReceived" message
