### PR TITLE
Do not modify original headers object.

### DIFF
--- a/lib/captured-connection.js
+++ b/lib/captured-connection.js
@@ -41,7 +41,7 @@ class CapturedConnection {
             url: res.url,
             statusCode: proxyRes.statusCode,
             statusMessage: proxyRes.statusMessage,
-            headers: adaptHeaders(proxyRes.headers),
+            headers: flattenHeaders(proxyRes.headers),
             rawHeaders: recreateRawResponseHeaders(proxyRes),
             connectionId: res.connection.remotePort
         };
@@ -207,16 +207,20 @@ ${headerString}`;
 }
 
 // response object keeps some params (like cookies) in an array, devtools don't like that, they want a string
-function adaptHeaders(headers) {
-    for (let name in headers) {
-        let values = headers[name];
+function flattenHeaders(headers) {
+    let flatHeaders = {};
 
-        if (Array.isArray(values)) {
-            headers[name] = values.join('\n');
+    for (let name in headers) {
+        let value = headers[name];
+
+        if (Array.isArray(value)) {
+            value = value.join('\n');
         }
+
+        flatHeaders[name] = value;
     }
 
-    return headers;
+    return flatHeaders;
 }
 
 module.exports = CapturedConnection;


### PR DESCRIPTION
Flattening the original headers object was breaking the cookies.

Fixes #27 
