### PR TITLE
Add mark-as-trusted step to OSX HTTPS config docs

### DIFF
--- a/docs/https.md
+++ b/docs/https.md
@@ -13,7 +13,7 @@ On OS X this is done via Keychain app as shown below.
 
 ![Installing certificate on OS X](http://i.imgur.com/lm2TIw4.png)
 
-...Open the certificate, expand the `Trust` section and toggle the first dropdown to `Always Trust`:
+After certificate is installed, expand the `Trust` section and toggle the first dropdown to `Always Trust`:
 
 ![Always trust](https://i.imgur.com/rQyHMUG.png)
 

--- a/docs/https.md
+++ b/docs/https.md
@@ -13,6 +13,10 @@ On OS X this is done via Keychain app as shown below.
 
 ![Installing certificate on OS X](http://i.imgur.com/lm2TIw4.png)
 
+...Open the certificate, expand the `Trust` section and toggle the first dropdown to `Always Trust`:
+
+![Always trust](https://i.imgur.com/rQyHMUG.png)
+
 On Windows use certmgr.
 
 ![Installing certificate on Windows 10](http://i.imgur.com/8IWpKR0.png)


### PR DESCRIPTION
Following on from confusion in #3